### PR TITLE
Improvements to SDWebImage

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -37,6 +37,12 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 @interface SDImageCache : NSObject
 
 /**
+ * Decompressing images that are downloaded and cached can improve peformance but can consume lot of memory.
+ * Defaults to YES. Set this to NO if you are experiencing a crash due to excessive memory consumption.
+ */
+@property (assign, nonatomic) BOOL shouldDecompressImages;
+
+/**
  * The maximum "total cost" of the in-memory image cache. The cost function is the number of pixels held in memory.
  */
 @property (assign, nonatomic) NSUInteger maxMemoryCost;

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -266,6 +266,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 - (UIImage *)diskImageForKey:(NSString *)key {
     NSData *data = [self diskImageDataBySearchingAllPathsForKey:key];
     if (data) {
+        // @@ 3636 prc use standard `imageWithData`
         UIImage *image = [UIImage imageWithData:data];
         if(self.shouldDecompressImages) {
             image = [UIImage decodedImageWithImage:image];

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -266,8 +266,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 - (UIImage *)diskImageForKey:(NSString *)key {
     NSData *data = [self diskImageDataBySearchingAllPathsForKey:key];
     if (data) {
-        UIImage *image = [UIImage sd_imageWithData:data];
-        image = [self scaledImageForKey:key image:image];
+        UIImage *image = [UIImage imageWithData:data];
         if(self.shouldDecompressImages) {
             image = [UIImage decodedImageWithImage:image];
         }

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -81,6 +81,8 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
             _fileManager = [NSFileManager new];
         });
 
+        _shouldDecompressImages = YES;
+
 #if TARGET_OS_IPHONE
         // Subscribe to app events
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -266,7 +268,9 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
     if (data) {
         UIImage *image = [UIImage sd_imageWithData:data];
         image = [self scaledImageForKey:key image:image];
-        image = [UIImage decodedImageWithImage:image];
+        if(self.shouldDecompressImages) {
+            image = [UIImage decodedImageWithImage:image];
+        }
         return image;
     }
     else {

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -79,6 +79,12 @@ typedef NSDictionary *(^SDWebImageDownloaderHeadersFilterBlock)(NSURL *url, NSDi
  */
 @interface SDWebImageDownloader : NSObject
 
+/**
+ * Decompressing images that are downloaded and cached can improve peformance but can consume lot of memory.
+ * Defaults to YES. Set this to NO if you are experiencing a crash due to excessive memory consumption.
+ */
+@property (assign, nonatomic) BOOL shouldDecompressImages;
+
 @property (assign, nonatomic) NSInteger maxConcurrentDownloads;
 
 /**

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -163,10 +163,16 @@ static NSString *const kCompletedCallbackKey = @"completed";
         
         if (options & SDWebImageDownloaderHighPriority) {
             operation.queuePriority = NSOperationQueuePriorityHigh;
-            operation.qualityOfService = NSQualityOfServiceUserInitiated;
+            // @@ 3636 prc add quality of service denotion
+            if([operation respondsToSelector:@selector(setQualityOfService:)]) {
+                [operation setQualityOfService:NSQualityOfServiceUserInitiated];
+            }
         } else if (options & SDWebImageDownloaderLowPriority) {
             operation.queuePriority = NSOperationQueuePriorityLow;
-            operation.qualityOfService = NSQualityOfServiceUtility;
+            // @@ 3636 prc add quality of service denotion
+            if([operation respondsToSelector:@selector(setQualityOfService:)]) {
+                [operation setQualityOfService:NSQualityOfServiceUtility];
+            }
         }
 
         [wself.downloadQueue addOperation:operation];

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -163,8 +163,10 @@ static NSString *const kCompletedCallbackKey = @"completed";
         
         if (options & SDWebImageDownloaderHighPriority) {
             operation.queuePriority = NSOperationQueuePriorityHigh;
+            operation.qualityOfService = NSQualityOfServiceUserInitiated;
         } else if (options & SDWebImageDownloaderLowPriority) {
             operation.queuePriority = NSOperationQueuePriorityLow;
+            operation.qualityOfService = NSQualityOfServiceUtility;
         }
 
         [wself.downloadQueue addOperation:operation];

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -23,9 +23,6 @@ static NSString *const kCompletedCallbackKey = @"completed";
 @property (assign, nonatomic) Class operationClass;
 @property (strong, nonatomic) NSMutableDictionary *URLCallbacks;
 @property (strong, nonatomic) NSMutableDictionary *HTTPHeaders;
-// This queue is used to serialize the handling of the network responses of all the download operation in a single queue
-@property (SDDispatchQueueSetterSementics, nonatomic) dispatch_queue_t barrierQueue;
-
 @end
 
 @implementation SDWebImageDownloader
@@ -70,15 +67,14 @@ static NSString *const kCompletedCallbackKey = @"completed";
         _downloadQueue.maxConcurrentOperationCount = 6;
         _URLCallbacks = [NSMutableDictionary new];
         _HTTPHeaders = [NSMutableDictionary dictionaryWithObject:@"image/webp,image/*;q=0.8" forKey:@"Accept"];
-        _barrierQueue = dispatch_queue_create("com.hackemist.SDWebImageDownloaderBarrierQueue", DISPATCH_QUEUE_CONCURRENT);
         _downloadTimeout = 15.0;
+        _shouldDecompressImages = YES;
     }
     return self;
 }
 
 - (void)dealloc {
     [self.downloadQueue cancelAllOperations];
-    SDDispatchQueueRelease(_barrierQueue);
 }
 
 - (void)setValue:(NSString *)value forHTTPHeaderField:(NSString *)field {
@@ -158,7 +154,9 @@ static NSString *const kCompletedCallbackKey = @"completed";
                                                             if (!sself) return;
                                                             [sself removeCallbacksForURL:url];
                                                         }];
-        
+
+        operation.shouldDecompressImages = wself.shouldDecompressImages;
+
         if (wself.username && wself.password) {
             operation.credential = [NSURLCredential credentialWithUser:wself.username password:wself.password persistence:NSURLCredentialPersistenceForSession];
         }
@@ -189,7 +187,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
         return;
     }
 
-    dispatch_barrier_sync(self.barrierQueue, ^{
+    @synchronized(self.URLCallbacks) {
         BOOL first = NO;
         if (!self.URLCallbacks[url]) {
             self.URLCallbacks[url] = [NSMutableArray new];
@@ -207,21 +205,21 @@ static NSString *const kCompletedCallbackKey = @"completed";
         if (first) {
             createCallback();
         }
-    });
+    }
 }
 
 - (NSArray *)callbacksForURL:(NSURL *)url {
     __block NSArray *callbacksForURL;
-    dispatch_sync(self.barrierQueue, ^{
+    @synchronized(self.URLCallbacks) {
         callbacksForURL = self.URLCallbacks[url];
-    });
+    }
     return [callbacksForURL copy];
 }
 
 - (void)removeCallbacksForURL:(NSURL *)url {
-    dispatch_barrier_async(self.barrierQueue, ^{
+    @synchronized(self.URLCallbacks) {
         [self.URLCallbacks removeObjectForKey:url];
-    });
+    }
 }
 
 - (void)setSuspended:(BOOL)suspended {

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -13,6 +13,12 @@
 @interface SDWebImageDownloaderOperation : NSOperation <SDWebImageOperation>
 
 /**
+ * Decompressing images that are downloaded and cached can improve peformance but can consume lot of memory.
+ * Defaults to YES. Set this to NO if you are experiencing a crash due to excessive memory consumption.
+ */
+@property (assign, nonatomic) BOOL shouldDecompressImages;
+
+/**
  * The request used by the operation's connection.
  */
 @property (strong, nonatomic, readonly) NSURLRequest *request;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -361,9 +361,10 @@
             completionBlock(nil, nil, nil, YES);
         }
         else {
-            UIImage *image = [UIImage sd_imageWithData:self.imageData];
-            NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-            image = [self scaledImageForKey:key image:image];
+            UIImage *image = [UIImage imageWithData:self.imageData];
+            //UIImage *image = [UIImage sd_imageWithData:self.imageData];
+            //NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+            //image = [self scaledImageForKey:key image:image];
             
             // Do not force decoding animated GIFs
             if (!image.images && self.shouldDecompressImages) {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -294,7 +294,9 @@
                 UIImage *image = [UIImage imageWithCGImage:partialImageRef scale:1 orientation:orientation];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 UIImage *scaledImage = [self scaledImageForKey:key image:image];
-                image = [UIImage decodedImageWithImage:scaledImage];
+                if(self.shouldDecompressImages) {
+                    image = [UIImage decodedImageWithImage:scaledImage];
+                }
                 CGImageRelease(partialImageRef);
                 dispatch_main_sync_safe(^{
                     if (self.completedBlock) {
@@ -364,7 +366,7 @@
             image = [self scaledImageForKey:key image:image];
             
             // Do not force decoding animated GIFs
-            if (!image.images) {
+            if (!image.images && self.shouldDecompressImages) {
                 image = [UIImage decodedImageWithImage:image];
             }
             if (CGSizeEqualToSize(image.size, CGSizeZero)) {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -361,10 +361,8 @@
             completionBlock(nil, nil, nil, YES);
         }
         else {
+            // @@ 3636 prc use standard `imageWithData`
             UIImage *image = [UIImage imageWithData:self.imageData];
-            //UIImage *image = [UIImage sd_imageWithData:self.imageData];
-            //NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-            //image = [self scaledImageForKey:key image:image];
             
             // Do not force decoding animated GIFs
             if (!image.images && self.shouldDecompressImages) {

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -77,11 +77,16 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     SDWebImageDelayPlaceholder = 1 << 9,
 
     /**
+     * No placeholder image is used
+     */
+    SDWebImageNoPlaceholder = 1 << 10,
+
+    /**
      * We usually don't call transformDownloadedImage delegate method on animated images,
      * as most transformation code would mangle it.
      * Use this flag to transform them anyway.
      */
-    SDWebImageTransformAnimatedImage = 1 << 10,
+    SDWebImageTransformAnimatedImage = 1 << 11,
 };
 
 typedef void(^SDWebImageCompletionBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL);

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -62,6 +62,16 @@
 - (void)sd_setImageWithURL:(NSURL *)url;
 
 /**
+ * Set the imageView `image` with an `url`, and custom options
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the image.
+ * @param options     The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ */
+- (void)sd_setImageWithURL:(NSURL *)url options:(SDWebImageOptions)options;
+
+/**
  * Set the imageView `image` with an `url` and a placeholder.
  *
  * The download is asynchronous and cached.

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -15,7 +15,11 @@ static char imageURLKey;
 @implementation UIImageView (WebCache)
 
 - (void)sd_setImageWithURL:(NSURL *)url {
-    [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:nil];
+    [self sd_setImageWithURL:url options:SDWebImageNoPlaceholder];
+}
+
+- (void)sd_setImageWithURL:(NSURL *)url options:(SDWebImageOptions)options{
+    [self sd_setImageWithURL:url placeholderImage:nil options:options progress:nil completed:nil];
 }
 
 - (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder {
@@ -42,7 +46,7 @@ static char imageURLKey;
     [self sd_cancelCurrentImageLoad];
     objc_setAssociatedObject(self, &imageURLKey, url, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    if (!(options & SDWebImageDelayPlaceholder)) {
+    if (!(options & SDWebImageDelayPlaceholder) && !(options & SDWebImageNoPlaceholder)) {
         dispatch_main_async_safe(^{
             self.image = placeholder;
         });
@@ -58,7 +62,7 @@ static char imageURLKey;
                     wself.image = image;
                     [wself setNeedsLayout];
                 } else {
-                    if ((options & SDWebImageDelayPlaceholder)) {
+                    if ((options & SDWebImageDelayPlaceholder) && !(options & SDWebImageNoPlaceholder)) {
                         wself.image = placeholder;
                         [wself setNeedsLayout];
                     }


### PR DESCRIPTION
- Add option to not decode images to limit memory consumption for large images
- Use `@synchronized` instead of `dispatch_barrier_async`
