### PR TITLE
IPAD-3636 Optimize memory usage for large download tasks

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -266,6 +266,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 - (UIImage *)diskImageForKey:(NSString *)key {
     NSData *data = [self diskImageDataBySearchingAllPathsForKey:key];
     if (data) {
+        // @@ 3636 prc use standard `imageWithData`
         UIImage *image = [UIImage imageWithData:data];
         if(self.shouldDecompressImages) {
             image = [UIImage decodedImageWithImage:image];

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -266,8 +266,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 - (UIImage *)diskImageForKey:(NSString *)key {
     NSData *data = [self diskImageDataBySearchingAllPathsForKey:key];
     if (data) {
-        UIImage *image = [UIImage sd_imageWithData:data];
-        image = [self scaledImageForKey:key image:image];
+        UIImage *image = [UIImage imageWithData:data];
         if(self.shouldDecompressImages) {
             image = [UIImage decodedImageWithImage:image];
         }

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -163,10 +163,16 @@ static NSString *const kCompletedCallbackKey = @"completed";
         
         if (options & SDWebImageDownloaderHighPriority) {
             operation.queuePriority = NSOperationQueuePriorityHigh;
-            operation.qualityOfService = NSQualityOfServiceUserInitiated;
+            // @@ 3636 prc add quality of service denotion
+            if([operation respondsToSelector:@selector(setQualityOfService:)]) {
+                [operation setQualityOfService:NSQualityOfServiceUserInitiated];
+            }
         } else if (options & SDWebImageDownloaderLowPriority) {
             operation.queuePriority = NSOperationQueuePriorityLow;
-            operation.qualityOfService = NSQualityOfServiceUtility;
+            // @@ 3636 prc add quality of service denotion
+            if([operation respondsToSelector:@selector(setQualityOfService:)]) {
+                [operation setQualityOfService:NSQualityOfServiceUtility];
+            }
         }
 
         [wself.downloadQueue addOperation:operation];

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -163,8 +163,10 @@ static NSString *const kCompletedCallbackKey = @"completed";
         
         if (options & SDWebImageDownloaderHighPriority) {
             operation.queuePriority = NSOperationQueuePriorityHigh;
+            operation.qualityOfService = NSQualityOfServiceUserInitiated;
         } else if (options & SDWebImageDownloaderLowPriority) {
             operation.queuePriority = NSOperationQueuePriorityLow;
+            operation.qualityOfService = NSQualityOfServiceUtility;
         }
 
         [wself.downloadQueue addOperation:operation];

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -361,9 +361,10 @@
             completionBlock(nil, nil, nil, YES);
         }
         else {
-            UIImage *image = [UIImage sd_imageWithData:self.imageData];
-            NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-            image = [self scaledImageForKey:key image:image];
+            UIImage *image = [UIImage imageWithData:self.imageData];
+            //UIImage *image = [UIImage sd_imageWithData:self.imageData];
+            //NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+            //image = [self scaledImageForKey:key image:image];
             
             // Do not force decoding animated GIFs
             if (!image.images && self.shouldDecompressImages) {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -361,10 +361,8 @@
             completionBlock(nil, nil, nil, YES);
         }
         else {
+            // @@ 3636 prc use standard `imageWithData`
             UIImage *image = [UIImage imageWithData:self.imageData];
-            //UIImage *image = [UIImage sd_imageWithData:self.imageData];
-            //NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-            //image = [self scaledImageForKey:key image:image];
             
             // Do not force decoding animated GIFs
             if (!image.images && self.shouldDecompressImages) {


### PR DESCRIPTION
- Remove use of `sd_imageWithData`, and use UIImage provided method
  - This method does not provide any real value, and may even contain memory leaks. Using the standard `imageWithData:` method is more reliable, and more future proof.
- Added QoS levels to NSOperations produced by the SDWebImageDownloader
  - Note: If an `NSOperation` is created on the main thread, then its QoS service level is denoted as "User Interative" which is the highest level. Because of how the SDWebImage threading is setup, the code that creates the operation is run on the main thread, thus implicitly setting a high QoS setting. 
